### PR TITLE
FIX model configuration to respect TRANSLATE_MODEL environment variable

### DIFF
--- a/markdown_translator/engine.py
+++ b/markdown_translator/engine.py
@@ -93,6 +93,7 @@ class TranslationEngine:
             self.translator = TranslationPool(
                 concurrency=5,
                 api_client=api_client,
+                model=self.config_manager.get_model_name(),
                 validator=self.validator,
                 performance_monitor=self.performance_monitor,
                 security_manager=self.security_manager
@@ -585,6 +586,7 @@ def create_translation_engine(chunk_size: int = 500,
     translator = TranslationPool(
         concurrency=concurrency,
         api_client=api_client,
+        model=config_manager.get_model_name(),
         validator=validator,
         performance_monitor=performance_monitor,
         security_manager=security_manager

--- a/markdown_translator/translator.py
+++ b/markdown_translator/translator.py
@@ -73,16 +73,18 @@ class TranslationPool(ITranslator):
     - Error classification and recovery
     """
     
-    def __init__(self, concurrency: int = 5, api_client: Optional[OpenAI] = None, 
-                 validator: Optional[IValidator] = None, retry_strategy: Optional[RetryStrategy] = None,
+    def __init__(self, concurrency: int = 5, api_client: Optional[OpenAI] = None,
+                 model: Optional[str] = None, validator: Optional[IValidator] = None,
+                 retry_strategy: Optional[RetryStrategy] = None,
                  performance_monitor: Optional[PerformanceMonitor] = None,
                  security_manager: Optional[SecurityManager] = None):
         """
         Initialize the translation pool.
-        
+
         Args:
             concurrency: Maximum number of concurrent translation tasks
             api_client: Configured OpenAI client for API calls
+            model: Model name to use for translation (defaults to qwen/qwen-2.5-72b-instruct if None)
             validator: Content integrity validator
             retry_strategy: Retry configuration
             performance_monitor: Performance monitoring instance
@@ -90,6 +92,7 @@ class TranslationPool(ITranslator):
         """
         self.concurrency = concurrency
         self.api_client = api_client
+        self.model = model
         self.validator = validator
         self.retry_strategy = retry_strategy or RetryStrategy()
         self.performance_monitor = performance_monitor
@@ -396,7 +399,7 @@ class TranslationPool(ITranslator):
         """
         try:
             response = self.api_client.chat.completions.create(
-                model="qwen/qwen-2.5-72b-instruct",  # Default model
+                model=self.model or "qwen/qwen-2.5-72b-instruct",  # Default model
                 messages=[
                     {
                         "role": "user",


### PR DESCRIPTION
## Summary
- Fixed model configuration to respect `TRANSLATE_MODEL` environment variable instead of using hardcoded value
- Added `model` parameter to `TranslationPool` constructor
- Pass model from `ConfigManager` to all `TranslationPool` instances
- Maintain backward compatibility with default fallback to `qwen/qwen-2.5-72b-instruct`

## Changes Made
1. **`translator.py`**:
   - Added `model` parameter to `TranslationPool.__init__()`
   - Store model as instance attribute
   - Updated `_make_api_call_with_retry()` to use `self.model` with fallback

2. **`engine.py`**:
   - Updated `TranslationEngine` initialization to pass model from config
   - Updated `create_translation_engine()` factory function to pass model

## Test Plan
- [x] Verify syntax and imports pass
- [x] Test config manager loads model from environment variable
- [x] Test TranslationPool accepts and uses model parameter
- [x] Test default fallback works when model is None or empty
- [x] Test CLI dry-run displays correct model from configuration

## Impact
- Users can now configure translation model via `TRANSLATE_MODEL` environment variable
- Maintains backward compatibility with existing configurations
- No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)